### PR TITLE
Package: Change node version to 14

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -10,7 +10,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "16"
+    "node": "14"
   },
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
Move version back from v16 to v14. Using version 16 causes a build error when deploying. Only versions 10, 12 and 14 are valid choices.