### PR TITLE
Misc tweaks

### DIFF
--- a/functions/src/tasks/controller.ts
+++ b/functions/src/tasks/controller.ts
@@ -48,12 +48,12 @@ export async function all (req: Request, res: Response): Promise<Response<void>>
 		const db = admin.firestore();
 		const firestoreRef = await db.collection("tasks").doc(`businessId-${businessId}`)
 			.collection("tasks").get();
-		const tasks = [{}];
+		const tasks = [{}]; // Start array with placeholder object.
 		firestoreRef.forEach((doc) => {
 			const data = doc.data();
 			tasks.push(data);
 		});
-		tasks.shift();
+		tasks.shift(); // Remove placeholder object from array.
 		return res.status(200).send(tasks);
 	} catch (err) {
 		return handleError(res, err);

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -129,7 +129,7 @@ function Calendar (props) {
 		<FullCalendar
 			plugins={[ dayGridPlugin, listPlugin ]}
 			headerToolbar={{
-				start: "prev,next today addEvent",
+				start: `prev,next today${props.role === "staff" ? "" : " addEvent"}`,
 				center: "title",
 				end: "calendar dayList,weekList",
 			}}

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -91,7 +91,7 @@ function Calendar (props) {
 	}
 
 	// Opens a modal so the user can input information and create event.
-	function addEvent () {
+	function addTask () {
 		props.setTaskModalVisible(true);
 	}
 
@@ -129,14 +129,14 @@ function Calendar (props) {
 		<FullCalendar
 			plugins={[ dayGridPlugin, listPlugin ]}
 			headerToolbar={{
-				start: `prev,next today${props.role === "staff" ? "" : " addEvent"}`,
+				start: `prev,next today${props.role === "staff" ? "" : " addTask"}`,
 				center: "title",
 				end: "calendar dayList,weekList",
 			}}
 			customButtons={{
-				addEvent: {
+				addTask: {
 					text: "+",
-					click: addEvent,
+					click: addTask,
 				}
 			}}
 			views={{

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -129,6 +129,7 @@ function Calendar (props) {
 		<FullCalendar
 			plugins={[ dayGridPlugin, listPlugin ]}
 			headerToolbar={{
+				// Do not render addTask button for staff user.
 				start: `prev,next today${props.role === "staff" ? "" : " addTask"}`,
 				center: "title",
 				end: "calendar dayList,weekList",

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -1,19 +1,9 @@
 import styled from "styled-components";
-import { secondaryMain, secondaryLight, textMain, buttonShadow } from "./../util/colours";
+import { secondaryLight, secondaryMain, tertiaryLight, textMain, buttonShadow } from "./../util/colours";
 import { GenericButtonProps } from "./../util/types";
 
 
-function MenuItem (props: GenericButtonProps): JSX.Element {
-	const label = props.label;
-
-	return (
-		<Item onClick={props.onClick}>
-			{label}
-		</Item>
-	);
-}
-
-const Item = styled.div`
+const Item = styled.div<{label: string, active: string}>`
 	background-color: ${secondaryMain};
 	box-shadow: ${buttonShadow};
 	border-radius: 4px;
@@ -24,11 +14,20 @@ const Item = styled.div`
 	width: 60px;
 	padding: 10px;
 	margin-bottom: 10px;
+	border: ${props => props.label.toLowerCase() === props.active ? `2px solid ${tertiaryLight};` : "none;"}
 	&:hover {
 		background-color: ${secondaryLight};
 		cursor: pointer;
 	}
 `;
+
+function MenuItem (props: GenericButtonProps): JSX.Element {
+	return (
+		<Item onClick={props.onClick} label={props.label} active={props.active}>
+			{props.label}
+		</Item>
+	);
+}
 
 
 export default MenuItem;

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -4,10 +4,11 @@ import { GenericButtonProps } from "./../util/types";
 
 
 function MenuItem (props: GenericButtonProps): JSX.Element {
+	const label = props.label;
 
 	return (
 		<Item onClick={props.onClick}>
-			{props.label}
+			{label}
 		</Item>
 	);
 }

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -151,7 +151,7 @@ function Homepage (): JSX.Element {
 						{!menuItemSelected && <h3 style={styles.noMenuItemText}>Select an action from the menu items on the left</h3>}
 						{peopleActive && <People businessId={businessId} role={role} />}
 						{calendarActive && <Calendar setTaskModalVisible={setTaskModalVisible} businessId={businessId} tasks={tasks} setTasks={setTasks} role={role} />}
-						<TaskModal taskModalVisible={taskModalVisible} setTaskModalVisible={setTaskModalVisible} businessId={businessId} role={role} tasks={tasks} setTasks={setTasks} />
+						{role !== "staff" && <TaskModal taskModalVisible={taskModalVisible} setTaskModalVisible={setTaskModalVisible} businessId={businessId} role={role} tasks={tasks} setTasks={setTasks} />}
 					</div>
 				</section>
 			</div>

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -17,7 +17,6 @@ function Homepage (): JSX.Element {
 	const [businessName, setBusinessName] = useState(null);
 	const [menuItemSelected, setMenuItemSelected] = useState(false);
 	const [peopleActive, setPeopleActive] = useState(false);
-	const [tasksActive, setTasksActive] = useState(false);
 	const [calendarActive, setCalendarActive] = useState(false);
 	const [taskModalVisible, setTaskModalVisible] = useState(false);
 	const [tasks, setTasks] = useState([]);
@@ -45,22 +44,13 @@ function Homepage (): JSX.Element {
 
 	function peopleMenuItem () {
 		setMenuItemSelected(true);
-		setTasksActive(false);
 		setCalendarActive(false);
 		setPeopleActive(true);
-	}
-
-	function tasksMenuItem () {
-		setMenuItemSelected(true);
-		setPeopleActive(false);
-		setCalendarActive(false);
-		setTasksActive(true);
 	}
 
 	function calendarMenuItem () {
 		setMenuItemSelected(true);
 		setPeopleActive(false);
-		setTasksActive(false);
 		setCalendarActive(true);
 	}
 
@@ -148,13 +138,11 @@ function Homepage (): JSX.Element {
 				<section style={styles.menuWrapper}>
 					<div style={styles.menuItems}>
 						{(role === "owner" || role === "manager") && <MenuItem label="People" onClick={peopleMenuItem} />}
-						<MenuItem label="Tasks" onClick={tasksMenuItem} />
 						<MenuItem label="Calendar" onClick={calendarMenuItem} />
 					</div>
 					<div style={styles.menuContent}>
 						{!menuItemSelected && <h3 style={styles.noMenuItemText}>Select an action from the menu items on the left</h3>}
 						{peopleActive && <People businessId={businessId} role={role} />}
-						{tasksActive && <h3>Tasks Placeholder</h3>}
 						{calendarActive && <Calendar setTaskModalVisible={setTaskModalVisible} businessId={businessId} tasks={tasks} setTasks={setTasks} />}
 						<TaskModal taskModalVisible={taskModalVisible} setTaskModalVisible={setTaskModalVisible} businessId={businessId} role={role} tasks={tasks} setTasks={setTasks} />
 					</div>

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -15,7 +15,7 @@ function Homepage (): JSX.Element {
 	const [role, setRole] = useState(null);
 	const [businessId, setBusinessId] = useState(null);
 	const [businessName, setBusinessName] = useState(null);
-	const [menuItemSelected, setMenuItemSelected] = useState("");
+	const [menuItem, setMenuItem] = useState("");
 	const [taskModalVisible, setTaskModalVisible] = useState(false);
 	const [tasks, setTasks] = useState([]);
 
@@ -41,11 +41,11 @@ function Homepage (): JSX.Element {
 	}
 
 	function peopleMenuItem () {
-		setMenuItemSelected("people");
+		setMenuItem("people");
 	}
 
 	function calendarMenuItem () {
-		setMenuItemSelected("calendar");
+		setMenuItem("calendar");
 	}
 
 	useEffect(() => {
@@ -59,7 +59,7 @@ function Homepage (): JSX.Element {
 
 	useEffect(() => {
 		if (role === "staff") {
-			setMenuItemSelected("calendar");
+			setMenuItem("calendar");
 		}
 	}, [role]);
 
@@ -112,10 +112,10 @@ function Homepage (): JSX.Element {
 			marginTop: "10px",
 			marginLeft: "10px",
 			padding: "10px",
-			background: menuItemSelected === "calendar" ? secondaryLight : "inherit",
+			background: menuItem === "calendar" ? secondaryLight : "inherit",
 			border: `2px ${tertiaryMain} solid`,
 			borderRadius: "10px",
-			width: menuItemSelected === "calendar" ? "100%" : "auto",
+			width: menuItem === "calendar" ? "100%" : "auto",
 			color: textAlt,
 		},
 		noMenuItemText: {
@@ -141,9 +141,9 @@ function Homepage (): JSX.Element {
 						<MenuItem label="Calendar" onClick={calendarMenuItem} />
 					</div>
 					<div style={styles.menuContent}>
-						{!menuItemSelected && <h3 style={styles.noMenuItemText}>Select an action from the menu items on the left</h3>}
-						{menuItemSelected === "people" && <People businessId={businessId} role={role} />}
-						{menuItemSelected === "calendar" && <Calendar setTaskModalVisible={setTaskModalVisible} businessId={businessId} tasks={tasks} setTasks={setTasks} role={role} />}
+						{!menuItem && <h3 style={styles.noMenuItemText}>Select an action from the menu items on the left</h3>}
+						{menuItem === "people" && <People businessId={businessId} role={role} />}
+						{menuItem === "calendar" && <Calendar setTaskModalVisible={setTaskModalVisible} businessId={businessId} tasks={tasks} setTasks={setTasks} role={role} />}
 						{role !== "staff" && <TaskModal taskModalVisible={taskModalVisible} setTaskModalVisible={setTaskModalVisible} businessId={businessId} role={role} tasks={tasks} setTasks={setTasks} />}
 					</div>
 				</section>

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -40,14 +40,6 @@ function Homepage (): JSX.Element {
 		}
 	}
 
-	function peopleMenuItem () {
-		setMenuItem("people");
-	}
-
-	function calendarMenuItem () {
-		setMenuItem("calendar");
-	}
-
 	useEffect(() => {
 		if (user) {
 			fetchClaims();
@@ -137,8 +129,8 @@ function Homepage (): JSX.Element {
 				</header>
 				<section style={styles.menuWrapper}>
 					<div style={styles.menuItems}>
-						{(role === "owner" || role === "manager") && <MenuItem label="People" onClick={peopleMenuItem} />}
-						<MenuItem label="Calendar" onClick={calendarMenuItem} />
+						{(role === "owner" || role === "manager") && <MenuItem label="People" onClick={() => setMenuItem("people")} />}
+						<MenuItem label="Calendar" onClick={() => setMenuItem("calendar")} />
 					</div>
 					<div style={styles.menuContent}>
 						{!menuItem && <h3 style={styles.noMenuItemText}>Select an action from the menu items on the left</h3>}

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -123,20 +123,46 @@ function Homepage (): JSX.Element {
 				<header style={styles.header}>
 					<HeaderText text={headerName} />
 					<HeaderText text={headerRole} />
-					{role !== "owner" && <HeaderText text={headerBusiness} />}
-					{role === "owner" && <HeaderText text={headerBusinessId} />}
+					{role !== "owner" &&
+						<HeaderText text={headerBusiness} />}
+					{role === "owner" &&
+						<HeaderText text={headerBusinessId} />}
 					<LogoutButton />
 				</header>
 				<section style={styles.menuWrapper}>
 					<div style={styles.menuItems}>
-						{(role === "owner" || role === "manager") && <MenuItem label="People" onClick={() => setMenuItem("people")} />}
-						<MenuItem label="Calendar" onClick={() => setMenuItem("calendar")} />
+						{(role === "owner" || role === "manager") &&
+							<MenuItem
+								label="People"
+								onClick={() => setMenuItem("people")}
+							/>}
+						<MenuItem
+							label="Calendar"
+							onClick={() => setMenuItem("calendar")}
+						/>
 					</div>
 					<div style={styles.menuContent}>
-						{!menuItem && <h3 style={styles.noMenuItemText}>Select an action from the menu items on the left</h3>}
-						{menuItem === "people" && <People businessId={businessId} role={role} />}
-						{menuItem === "calendar" && <Calendar setTaskModalVisible={setTaskModalVisible} businessId={businessId} tasks={tasks} setTasks={setTasks} role={role} />}
-						{role !== "staff" && <TaskModal taskModalVisible={taskModalVisible} setTaskModalVisible={setTaskModalVisible} businessId={businessId} role={role} tasks={tasks} setTasks={setTasks} />}
+						{!menuItem &&
+							<h3 style={styles.noMenuItemText}>Select an action from the menu items on the left</h3>}
+						{menuItem === "people" &&
+							<People businessId={businessId} role={role} />}
+						{menuItem === "calendar" &&
+							<Calendar
+								setTaskModalVisible={setTaskModalVisible}
+								businessId={businessId}
+								tasks={tasks}
+								setTasks={setTasks}
+								role={role}
+							/>}
+						{role !== "staff" &&
+							<TaskModal
+								taskModalVisible={taskModalVisible}
+								setTaskModalVisible={setTaskModalVisible}
+								businessId={businessId}
+								role={role}
+								tasks={tasks}
+								setTasks={setTasks}
+							/>}
 					</div>
 				</section>
 			</div>

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -15,9 +15,7 @@ function Homepage (): JSX.Element {
 	const [role, setRole] = useState(null);
 	const [businessId, setBusinessId] = useState(null);
 	const [businessName, setBusinessName] = useState(null);
-	const [menuItemSelected, setMenuItemSelected] = useState(false);
-	const [peopleActive, setPeopleActive] = useState(false);
-	const [calendarActive, setCalendarActive] = useState(false);
+	const [menuItemSelected, setMenuItemSelected] = useState("");
 	const [taskModalVisible, setTaskModalVisible] = useState(false);
 	const [tasks, setTasks] = useState([]);
 
@@ -43,15 +41,11 @@ function Homepage (): JSX.Element {
 	}
 
 	function peopleMenuItem () {
-		setMenuItemSelected(true);
-		setCalendarActive(false);
-		setPeopleActive(true);
+		setMenuItemSelected("people");
 	}
 
 	function calendarMenuItem () {
-		setMenuItemSelected(true);
-		setPeopleActive(false);
-		setCalendarActive(true);
+		setMenuItemSelected("calendar");
 	}
 
 	useEffect(() => {
@@ -65,8 +59,7 @@ function Homepage (): JSX.Element {
 
 	useEffect(() => {
 		if (role === "staff") {
-			setMenuItemSelected(true);
-			setCalendarActive(true);
+			setMenuItemSelected("calendar");
 		}
 	}, [role]);
 
@@ -119,10 +112,10 @@ function Homepage (): JSX.Element {
 			marginTop: "10px",
 			marginLeft: "10px",
 			padding: "10px",
-			background: calendarActive ? secondaryLight : "inherit",
+			background: menuItemSelected === "calendar" ? secondaryLight : "inherit",
 			border: `2px ${tertiaryMain} solid`,
 			borderRadius: "10px",
-			width: calendarActive ? "100%" : "auto",
+			width: menuItemSelected === "calendar" ? "100%" : "auto",
 			color: textAlt,
 		},
 		noMenuItemText: {
@@ -149,8 +142,8 @@ function Homepage (): JSX.Element {
 					</div>
 					<div style={styles.menuContent}>
 						{!menuItemSelected && <h3 style={styles.noMenuItemText}>Select an action from the menu items on the left</h3>}
-						{peopleActive && <People businessId={businessId} role={role} />}
-						{calendarActive && <Calendar setTaskModalVisible={setTaskModalVisible} businessId={businessId} tasks={tasks} setTasks={setTasks} role={role} />}
+						{menuItemSelected === "people" && <People businessId={businessId} role={role} />}
+						{menuItemSelected === "calendar" && <Calendar setTaskModalVisible={setTaskModalVisible} businessId={businessId} tasks={tasks} setTasks={setTasks} role={role} />}
 						{role !== "staff" && <TaskModal taskModalVisible={taskModalVisible} setTaskModalVisible={setTaskModalVisible} businessId={businessId} role={role} tasks={tasks} setTasks={setTasks} />}
 					</div>
 				</section>

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -143,7 +143,7 @@ function Homepage (): JSX.Element {
 					<div style={styles.menuContent}>
 						{!menuItemSelected && <h3 style={styles.noMenuItemText}>Select an action from the menu items on the left</h3>}
 						{peopleActive && <People businessId={businessId} role={role} />}
-						{calendarActive && <Calendar setTaskModalVisible={setTaskModalVisible} businessId={businessId} tasks={tasks} setTasks={setTasks} />}
+						{calendarActive && <Calendar setTaskModalVisible={setTaskModalVisible} businessId={businessId} tasks={tasks} setTasks={setTasks} role={role} />}
 						<TaskModal taskModalVisible={taskModalVisible} setTaskModalVisible={setTaskModalVisible} businessId={businessId} role={role} tasks={tasks} setTasks={setTasks} />
 					</div>
 				</section>

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -63,6 +63,13 @@ function Homepage (): JSX.Element {
 		}
 	});
 
+	useEffect(() => {
+		if (role === "staff") {
+			setMenuItemSelected(true);
+			setCalendarActive(true);
+		}
+	}, [role]);
+
 	const styles: StyleSheet = {
 		root: {
 			display: "flex",

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -133,10 +133,12 @@ function Homepage (): JSX.Element {
 					<div style={styles.menuItems}>
 						{(role === "owner" || role === "manager") &&
 							<MenuItem
+								active={menuItem}
 								label="People"
 								onClick={() => setMenuItem("people")}
 							/>}
 						<MenuItem
+							active={menuItem}
 							label="Calendar"
 							onClick={() => setMenuItem("calendar")}
 						/>

--- a/src/pages/LoginSignup.tsx
+++ b/src/pages/LoginSignup.tsx
@@ -27,8 +27,8 @@ function LoginSignup (): JSX.Element {
 				<p style={styles.title}>Login</p>
 				<Login />
 				<p style={styles.title}>Sign Up</p>
-				<SignUpButton label="Create User Account" onClick={userForm} />
-				<SignUpButton label="Create Business Account" onClick={businessForm} />
+				<SignUpButton active={""} label="Create User Account" onClick={userForm} />
+				<SignUpButton active={""} label="Create Business Account" onClick={businessForm} />
 			</header>
 			{userFormActive && <CreateUser />}
 			{businessFormActive && <CreateBusiness />}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -11,6 +11,7 @@ export interface StyleSheet {
 
 // Prop shape for the GenericButton component.
 export interface GenericButtonProps {
+  active: string;
   label: string;
   onClick: ((event: MouseEvent) => void) | undefined;
 }


### PR DESCRIPTION
Several tweaks and user restrictions as outlined below:

- Remove the 'Tasks' `MenuItem` as it's intended functionality has been fully integrated into 'Calendar'.
- Prevent render of `addTask` button within Calendar when user `role` is `staff`.
- Automatically load the `<Calender/>` component when the user `role` is `staff`. With the removal of the Tasks `MenuItem`, the `staff` user only has a single `MenuItem` remaining to select.
- Remove an unnecessary call made by `staff` users to `GET` all `users`. Only the other user types need to make this call in order to populate the 'People' `MenuItem`. The call has resulted in an error as the `staff` users were being blocked by the role-based api implemented in the backend.
- Detect which `MenuItem` is active and add a border to the UI when so.
- Refactor several files including consolidating several states into one, renaming variables and adding comments.