### PR TITLE
Restrict tasks for staff users

### DIFF
--- a/functions/src/tasks/controller.ts
+++ b/functions/src/tasks/controller.ts
@@ -41,6 +41,27 @@ export async function create (req: Request, res: Response): Promise<Response<voi
 	}
 }
 
+// Get the tasks assigned to the user of a given uid.
+export async function assigned (req: Request, res: Response): Promise<Response<void>> {
+	try {
+		const { userId, businessId } = req.params;
+		const db = admin.firestore();
+		const firestoreRef = await db.collection("tasks").doc(`businessId-${businessId}`)
+			.collection("tasks").get();
+		const tasks = [{}]; // Start array with placeholder object.
+		firestoreRef.forEach((doc) => {
+			const data = doc.data();
+			if (data.extendedProps.assigneeUids.includes(userId)) {
+				tasks.push(data);
+			}
+		});
+		tasks.shift(); // Remove placeholder object from array.
+		return res.status(200).send(tasks);
+	} catch (err) {
+		return handleError(res, err);
+	}
+}
+
 // Get all tasks from the Firestore.
 export async function all (req: Request, res: Response): Promise<Response<void>> {
 	try {

--- a/functions/src/tasks/controller.ts
+++ b/functions/src/tasks/controller.ts
@@ -50,9 +50,9 @@ export async function assigned (req: Request, res: Response): Promise<Response<v
 			.collection("tasks").get();
 		const tasks = [{}]; // Start array with placeholder object.
 		firestoreRef.forEach((doc) => {
-			const data = doc.data();
-			if (data.extendedProps.assigneeUids.includes(userId)) {
-				tasks.push(data);
+			const task = doc.data();
+			if (task.extendedProps.assigneeUids.includes(userId)) {
+				tasks.push(task);
 			}
 		});
 		tasks.shift(); // Remove placeholder object from array.
@@ -71,8 +71,8 @@ export async function all (req: Request, res: Response): Promise<Response<void>>
 			.collection("tasks").get();
 		const tasks = [{}]; // Start array with placeholder object.
 		firestoreRef.forEach((doc) => {
-			const data = doc.data();
-			tasks.push(data);
+			const task = doc.data();
+			tasks.push(task);
 		});
 		tasks.shift(); // Remove placeholder object from array.
 		return res.status(200).send(tasks);

--- a/functions/src/tasks/tasksRoute.ts
+++ b/functions/src/tasks/tasksRoute.ts
@@ -1,5 +1,5 @@
 import { Application } from "express";
-import { create, all } from "./controller";
+import { create, assigned, all } from "./controller";
 import { isAuthenticated } from "../auth/authenticated";
 import { isAuthorised } from "../auth/authorised";
 
@@ -10,6 +10,12 @@ export function tasksRoute (app: Application): void {
 		isAuthenticated,
 		isAuthorised({ hasRole: ["owner", "manager"] }),
 		create
+	);
+	// GET tasks that have been assigned to the user.
+	app.get("/tasks/:userId/:businessId",
+		isAuthenticated,
+		isAuthorised({ hasRole: ["staff"] }),
+		assigned
 	);
 	// GET all tasks.
 	app.get("/tasks/:businessId",

--- a/functions/src/tasks/tasksRoute.ts
+++ b/functions/src/tasks/tasksRoute.ts
@@ -20,7 +20,7 @@ export function tasksRoute (app: Application): void {
 	// GET all tasks.
 	app.get("/tasks/:businessId",
 		isAuthenticated,
-		isAuthorised({ hasRole: ["owner", "manager", "staff"] }),
+		isAuthorised({ hasRole: ["owner", "manager"] }),
 		all
 	);
 }

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -100,9 +100,9 @@ function Calendar (props) {
 	// Get all tasks and save to state in parent.
 	const fetchTasks = useCallback(
 		async () => {
-			const newTasks = await getTasks(businessId);
+			const newTasks = await getTasks(role, businessId, props.userId);
 			props.setTasks(newTasks);
-		}, [businessId, props]
+		}, [role, businessId, props]
 	);
 
 	// Set listeners for clicks on all buttons on initial render.

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -12,6 +12,7 @@ function Calendar (props) {
 	const [buttonClicked, setButtonClicked] = useState(false);
 
 	const businessId = props.businessId;
+	const tasks = props.tasks;
 
 	// Event handling for when task is clicked in any view.
 	function eventClicked (info) {
@@ -122,8 +123,8 @@ function Calendar (props) {
 
 	// Fetch tasks from Firestore on first render.
 	useEffect(() => {
-		if (props.tasks.length === 0) fetchTasks();
-	}, [fetchTasks, props.tasks]);
+		if (tasks.length === 0) fetchTasks();
+	}, [fetchTasks, tasks]);
 
 	return (
 		<FullCalendar
@@ -163,7 +164,7 @@ function Calendar (props) {
 			initialView="calendar"
 			fixedWeekCount={false}
 			firstDay={1}
-			events={props.tasks}
+			events={tasks}
 			eventColor={tertiaryMain}
 			eventTextColor={textAlt}
 			dayMaxEventRows={4}

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -13,6 +13,7 @@ function Calendar (props) {
 
 	const businessId = props.businessId;
 	const tasks = props.tasks;
+	const role = props.role;
 
 	// Event handling for when task is clicked in any view.
 	function eventClicked (info) {
@@ -131,7 +132,7 @@ function Calendar (props) {
 			plugins={[ dayGridPlugin, listPlugin ]}
 			headerToolbar={{
 				// Do not render addTask button for staff user.
-				start: `prev,next today${props.role === "staff" ? "" : " addTask"}`,
+				start: `prev,next today${role === "staff" ? "" : " addTask"}`,
 				center: "title",
 				end: "calendar dayList,weekList",
 			}}

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -24,6 +24,7 @@ function TaskModal (props): JSX.Element {
 
 	const { user } = useAuth();
 	const businessId = props.businessId;
+	const role = props.role;
 	const formattedAssignees = assignees.map(assignee => assignee.value).toString();
 	const formattedAssigneeUids = assignees.map(assignee => assignee.uid).toString();
 	Modal.setAppElement("#root");
@@ -78,7 +79,7 @@ function TaskModal (props): JSX.Element {
 	}
 
 	function getFullName () {
-		if (props.role === "owner") {
+		if (role === "owner") {
 			return user.displayName;
 		} else {
 			const currentUser = users.find(person => person.uid === user.uid);

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -154,9 +154,9 @@ function TaskModal (props): JSX.Element {
 
 	const fetchTasks = useCallback(
 		async () => {
-			const newTasks = await getTasks(businessId);
+			const newTasks = await getTasks(role, businessId, props.userId);
 			props.setTasks(newTasks);
-		}, [businessId, props]
+		}, [role, businessId, props]
 	);
 
 	useEffect(() => {

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -38,13 +38,13 @@ function Homepage (): JSX.Element {
 		const data = await getBusinessData(user, businessId);
 		if (data) {
 			setBusinessName(data.displayName);
-			setUserId(data.uid);
 		}
 	}
 
 	useEffect(() => {
 		if (user) {
 			fetchClaims();
+			setUserId(user.uid);
 		}
 		if (user && businessId) {
 			fetchBusinessData();

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { primaryMain, secondaryMain, secondaryLight, tertiaryMain, textMain, textAlt } from "./../util/colours";
 import LogoutButton from "./../components/LogoutButton";
 import HeaderText from "./../components/HeaderText";
@@ -26,20 +26,24 @@ function Homepage (): JSX.Element {
 	const headerBusiness = `Business: ${businessName}`;
 	const headerBusinessId = `Business ID: ${businessId}`;
 
-	async function fetchClaims () {
-		const claims = await getClaims(user);
-		if (claims) {
-			setRole(claims.role);
-			setBusinessId(claims.businessId);
-		}
-	}
+	const fetchClaims = useCallback(
+		async () => {
+			const claims = await getClaims(user);
+			if (claims) {
+				setRole(claims.role);
+				setBusinessId(claims.businessId);
+			}
+		}, [user]
+	);
 
-	async function fetchBusinessData () {
-		const data = await getBusinessData(user, businessId);
-		if (data) {
-			setBusinessName(data.displayName);
-		}
-	}
+	const fetchBusinessData = useCallback(
+		async () => {
+			const data = await getBusinessData(user, businessId);
+			if (data) {
+				setBusinessName(data.displayName);
+			}
+		}, [user, businessId]
+	);
 
 	useEffect(() => {
 		if (user) {
@@ -49,7 +53,7 @@ function Homepage (): JSX.Element {
 		if (user && businessId) {
 			fetchBusinessData();
 		}
-	});
+	}, [user, businessId, fetchClaims, fetchBusinessData]);
 
 	useEffect(() => {
 		if (role === "staff") {

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -13,6 +13,7 @@ import { StyleSheet } from "./../util/types";
 
 function Homepage (): JSX.Element {
 	const [role, setRole] = useState(null);
+	const [userId, setUserId] = useState(null);
 	const [businessId, setBusinessId] = useState(null);
 	const [businessName, setBusinessName] = useState(null);
 	const [menuItem, setMenuItem] = useState("");
@@ -37,6 +38,7 @@ function Homepage (): JSX.Element {
 		const data = await getBusinessData(user, businessId);
 		if (data) {
 			setBusinessName(data.displayName);
+			setUserId(data.uid);
 		}
 	}
 
@@ -151,6 +153,7 @@ function Homepage (): JSX.Element {
 						{menuItem === "calendar" &&
 							<Calendar
 								setTaskModalVisible={setTaskModalVisible}
+								userId={userId}
 								businessId={businessId}
 								tasks={tasks}
 								setTasks={setTasks}
@@ -160,6 +163,7 @@ function Homepage (): JSX.Element {
 							<TaskModal
 								taskModalVisible={taskModalVisible}
 								setTaskModalVisible={setTaskModalVisible}
+								userId={userId}
 								businessId={businessId}
 								role={role}
 								tasks={tasks}

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -69,14 +69,19 @@ export async function getBusinessData (user: firebase.User, businessId: string) 
 	}
 }
 
-export async function getTasks (businessId) {
+export async function getTasks (role, businessId, userId) {
 	try {
 		const token = await firebase.auth().currentUser.getIdToken(true);
 		const requestOptions = {
 			method: "GET",
 			headers: { authorization: `Bearer ${token}` }
 		};
-		const res = await fetch(`${API_URL}/tasks/${businessId}`, requestOptions);
+		let res;
+		if (role === "staff") {
+			res = await fetch(`${API_URL}/tasks/${userId}/${businessId}`, requestOptions);
+		} else {
+			res = await fetch(`${API_URL}/tasks/${businessId}`, requestOptions);
+		}
 		const taskArray = await res.json();
 		return taskArray;
 	} catch (error) {


### PR DESCRIPTION
Restrict the array of `tasks` sent to a `staff` user to include only those to which they have been assigned by doing the following:

**Front-end**
- Create a new state variable `userId` in `<Calendar/>`.
- Pass `userId` and `role` states to the `getTasks` function.
- Add these two as parameters to `getTasks` in `helpers.ts`.
- Create a conditional here where a call is made to a different `api` endpoint when the user `role` is set to `staff`. This one will include the `userId` as a parameter.

**Back-end**
- Create a function called `assigned` in `controller.ts`. This is very similar to the `all` function except it takes the `userId` `param` and checks for matches in the `assigneeUids` array within each `task` taken from `Firestore`. Thus, an array is returned that only contains `tasks` to which the quering `staff` user belongs.
- Add the new `api` endpoint to `tasksRoute.ts` in order to route correctly and pass `auth` checks before running the `assigned` function. Authorise only `staff` users.
- Remove `staff` user from the `all` function authorization in `tasksRoute.ts`.