### PR TITLE
Adjust scripts

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -17,7 +17,7 @@
   "functions": {
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint",
-      "npm --prefix \"$RESOURCE_DIR\" run build-all"
+      "npm --prefix \"$RESOURCE_DIR\" run build"
     ],
     "source": "functions"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "serve": "npm run build-all && firebase emulators:start",
     "get-keys": "export GOOGLE_APPLICATION_CREDENTIALS='/Users/lucas/Downloads/onit-keys.json'",
     "deploy": "npm run build && firebase deploy --only hosting:onit-main",
-    "deploy-rules": "firebase deploy --only firestore:rules",
     "deploy-all": "npm run build && firebase deploy",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "lint": "eslint --ext .js,.ts,.tsx .",
     "serve": "npm run build-all && firebase emulators:start",
     "get-keys": "export GOOGLE_APPLICATION_CREDENTIALS='/Users/lucas/Downloads/onit-keys.json'",
-    "deploy": "firebase deploy --only hosting:onit-main",
+    "deploy": "npm run build && firebase deploy --only hosting:onit-main",
     "deploy-rules": "firebase deploy --only firestore:rules",
-    "deploy-all": "firebase deploy",
+    "deploy-all": "npm run build && firebase deploy",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Change some deployment-related scripts. The predeploy one in `firebase.json` had not been implemented correctly, and should just `build` the functions prior to deployment. Instead of `build-all` here, the `build` script is run before the deployment scripts in the root `package.json` file. This way, both functions and root files get built via seperate commands before deployment.

Could also remove unnecessary deployment script at root related to Firebase `rules`. Permissions are already managed via the `admin` SDK in functions rather than in the `rules` (the latter would be for requests made directly by the client rather than by the backend).