### PR TITLE
Implement MUI theme

### DIFF
--- a/src/components/CreateBusiness.tsx
+++ b/src/components/CreateBusiness.tsx
@@ -205,7 +205,7 @@ function CreateBusiness(): JSX.Element {
           helperText={passwordHelperText}
           sx={styles.inputField}
         />
-        <PrimaryButton label="submit" type="submit" disabled={loginDisabled} />
+        <PrimaryButton label="Submit" type="submit" disabled={loginDisabled} />
       </form>
       {user && <Redirect to="home" />}
     </div>

--- a/src/components/CreateUser.tsx
+++ b/src/components/CreateUser.tsx
@@ -177,7 +177,7 @@ function CreateUser(): JSX.Element {
           helperText={businessIdHelperText}
           sx={styles.inputField}
         />
-        <PrimaryButton label="submit" type="submit" disabled={loginDisabled} />
+        <PrimaryButton label="Submit" type="submit" disabled={loginDisabled} />
       </form>
       {user && <Redirect to="home" />}
     </div>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -90,7 +90,7 @@ function Login(): JSX.Element {
           helperText={passwordHelperText}
           sx={styles.inputField}
         />
-        <PrimaryButton label="login" type="submit" disabled={loginDisabled} />
+        <PrimaryButton label="Login" type="submit" disabled={loginDisabled} />
       </form>
       {user && <Redirect to="home" />}
     </div>

--- a/src/components/PhoneNumber.tsx
+++ b/src/components/PhoneNumber.tsx
@@ -10,6 +10,7 @@ const phoneInputStyles = { width: "79%", marginBottom: "15px" };
 type PhoneNumberProps = PhoneInputProps & { helperText: string };
 
 function PhoneNumber(props: PhoneNumberProps): JSX.Element {
+  const [isLoaded, setIsLoaded] = useState(false);
   const [inFocus, setInFocus] = useState(false);
 
   const { name, value, onChange, helperText } = props;
@@ -41,13 +42,16 @@ function PhoneNumber(props: PhoneNumberProps): JSX.Element {
   }
 
   useEffect(() => {
-    if (helperText) {
+    if (!isLoaded) {
+      // If page is not loaded, the outline setters can't fetch input.
+    } else if (helperText) {
       setErrorOutline();
     } else if (inFocus) {
       setFocusedOutline();
     } else {
       setBlurredOutline();
     }
+    setIsLoaded(true);
   });
 
   return (

--- a/src/components/PhoneNumber.tsx
+++ b/src/components/PhoneNumber.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import PhoneInput, { PhoneInputProps } from "react-phone-number-input";
-import { muiError, muiActive } from "../util/colours";
+import { muiError, muiFocus } from "../util/colours";
 import { COUNTRY_CODE } from "../util/constants";
 import "react-phone-number-input/style.css";
 import "./css/PhoneNumber.css";
@@ -31,7 +31,7 @@ function PhoneNumber(props: PhoneNumberProps): JSX.Element {
     if (helperText) {
       input.style.outlineColor = muiError;
     } else if (inFocus) {
-      input.style.outlineColor = muiActive;
+      input.style.outlineColor = muiFocus;
     } else {
       input.style.outlineColor = "#31353d";
     }

--- a/src/components/PhoneNumber.tsx
+++ b/src/components/PhoneNumber.tsx
@@ -22,7 +22,7 @@ function PhoneNumber(props: PhoneNumberProps): JSX.Element {
   const phoneHelperTextStyle = {
     display: displayStyle,
     fontSize: "12px",
-    color: "#d32f2f",
+    color: muiError,
     margin: "-12px 10px 22px",
   };
 

--- a/src/components/PhoneNumber.tsx
+++ b/src/components/PhoneNumber.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import PhoneInput, { PhoneInputProps } from "react-phone-number-input";
-import { muiBlur, muiError, muiFocus } from "../util/colours";
+import { muiBlur, muiError, muiFocus, muiHover } from "../util/colours";
 import { COUNTRY_CODE } from "../util/constants";
 import "react-phone-number-input/style.css";
 import "./css/PhoneNumber.css";
@@ -34,6 +34,10 @@ function PhoneNumber(props: PhoneNumberProps): JSX.Element {
   function setFocusedOutline() {
     input.style.outlineColor = muiFocus;
     setInFocus(true);
+  }
+
+  function setHoveringOutline() {
+    input.style.outlineColor = muiHover;
   }
 
   function setBlurredOutline() {
@@ -71,6 +75,8 @@ function PhoneNumber(props: PhoneNumberProps): JSX.Element {
         onChange={onChange}
         style={phoneInputStyles}
         onFocus={setFocusedOutline}
+        onMouseEnter={setHoveringOutline}
+        onMouseLeave={setOutline}
         onBlur={setBlurredOutline}
       />
       <p style={phoneHelperTextStyle}>{helperText}</p>

--- a/src/components/PhoneNumber.tsx
+++ b/src/components/PhoneNumber.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import PhoneInput, { PhoneInputProps } from "react-phone-number-input";
 import { muiBlur, muiError, muiFocus } from "../util/colours";
 import { COUNTRY_CODE } from "../util/constants";
@@ -10,7 +10,13 @@ const phoneInputStyles = { width: "79%", marginBottom: "15px" };
 type PhoneNumberProps = PhoneInputProps & { helperText: string };
 
 function PhoneNumber(props: PhoneNumberProps): JSX.Element {
+  const [inFocus, setInFocus] = useState(false);
+
   const { name, value, onChange, helperText } = props;
+
+  const input = document.getElementsByClassName(
+    "PhoneInputInput"
+  )[0] as HTMLElement;
 
   const displayStyle = helperText ? "inline" : "none";
   const phoneHelperTextStyle = {
@@ -20,20 +26,27 @@ function PhoneNumber(props: PhoneNumberProps): JSX.Element {
     margin: "-12px 10px 22px",
   };
 
-  useEffect(() => {
-    const input = document.getElementsByClassName(
-      "PhoneInputInput"
-    )[0] as HTMLElement;
-    const inFocus = document.getElementsByClassName(
-      "PhoneInput--focus"
-    )[0] as HTMLElement;
+  function setErrorOutline() {
+    input.style.outlineColor = muiError;
+  }
 
+  function setFocusedOutline() {
+    input.style.outlineColor = muiFocus;
+    setInFocus(true);
+  }
+
+  function setBlurredOutline() {
+    input.style.outlineColor = muiBlur;
+    setInFocus(false);
+  }
+
+  useEffect(() => {
     if (helperText) {
-      input.style.outlineColor = muiError;
+      setErrorOutline();
     } else if (inFocus) {
-      input.style.outlineColor = muiFocus;
+      setFocusedOutline();
     } else {
-      input.style.outlineColor = muiBlur;
+      setBlurredOutline();
     }
   });
 
@@ -47,6 +60,8 @@ function PhoneNumber(props: PhoneNumberProps): JSX.Element {
         value={value}
         onChange={onChange}
         style={phoneInputStyles}
+        onFocus={setFocusedOutline}
+        onBlur={setBlurredOutline}
       />
       <p style={phoneHelperTextStyle}>{helperText}</p>
     </div>

--- a/src/components/PhoneNumber.tsx
+++ b/src/components/PhoneNumber.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import PhoneInput, { PhoneInputProps } from "react-phone-number-input";
-import { muiError, muiFocus } from "../util/colours";
+import { muiBlur, muiError, muiFocus } from "../util/colours";
 import { COUNTRY_CODE } from "../util/constants";
 import "react-phone-number-input/style.css";
 import "./css/PhoneNumber.css";
@@ -33,7 +33,7 @@ function PhoneNumber(props: PhoneNumberProps): JSX.Element {
     } else if (inFocus) {
       input.style.outlineColor = muiFocus;
     } else {
-      input.style.outlineColor = "#31353d";
+      input.style.outlineColor = muiBlur;
     }
   });
 

--- a/src/components/PhoneNumber.tsx
+++ b/src/components/PhoneNumber.tsx
@@ -41,15 +41,21 @@ function PhoneNumber(props: PhoneNumberProps): JSX.Element {
     setInFocus(false);
   }
 
-  useEffect(() => {
-    if (!isLoaded) {
-      // If page is not loaded, the outline setters can't fetch input.
-    } else if (helperText) {
+  function setOutline() {
+    if (helperText) {
       setErrorOutline();
     } else if (inFocus) {
       setFocusedOutline();
     } else {
       setBlurredOutline();
+    }
+  }
+
+  useEffect(() => {
+    if (!isLoaded) {
+      // If page is not loaded, the outline setters can't fetch input.
+    } else {
+      setOutline();
     }
     setIsLoaded(true);
   });

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -239,7 +239,7 @@ function TaskModal(props): JSX.Element {
             onSelect={setAssignees}
           />
           <PrimaryButton
-            label="create task"
+            label="Create Task"
             type="submit"
             disabled={createTaskDisabled}
           />

--- a/src/components/css/PhoneNumber.css
+++ b/src/components/css/PhoneNumber.css
@@ -2,6 +2,7 @@
   margin: 3px 0px;
   padding: 15px 6px;
   height: 22px;
+  color: #ffffff;
   border-radius: 3px;
   font-size: 15px;
   outline-style: solid;

--- a/src/components/css/PhoneNumber.css
+++ b/src/components/css/PhoneNumber.css
@@ -11,7 +11,6 @@
 }
 
 .PhoneInputInput:focus {
-  outline-style: solid !important;
   outline-width: 2px !important;
   outline-color: #90caf9; /* This is muiFocus and never gets applied */
 }

--- a/src/components/css/PhoneNumber.css
+++ b/src/components/css/PhoneNumber.css
@@ -13,7 +13,6 @@
 
 .PhoneInputInput:focus {
   outline-width: 2px !important;
-  outline-color: #90caf9; /* This is muiFocus and never gets applied */
 }
 
 .phone-wrapper {

--- a/src/components/css/PhoneNumber.css
+++ b/src/components/css/PhoneNumber.css
@@ -7,6 +7,7 @@
   font-size: 15px;
   outline-style: solid;
   outline-width: 1px;
+  outline-color: rgba(255, 255, 255, 0.3); /* muiBlur from colours.ts */
   background-color: #3f4552; /* primaryLight from colours.ts */
 }
 

--- a/src/components/css/PhoneNumber.css
+++ b/src/components/css/PhoneNumber.css
@@ -11,7 +11,7 @@
 .PhoneInputInput:focus {
   outline-style: solid !important;
   outline-width: 2px !important;
-  outline-color: #1976d2; /* This never gets applied */
+  outline-color: #90caf9; /* This is muiActive and never gets applied */
 }
 
 .phone-wrapper {

--- a/src/components/css/PhoneNumber.css
+++ b/src/components/css/PhoneNumber.css
@@ -4,7 +4,8 @@
   height: 22px;
   border-radius: 3px;
   font-size: 15px;
-  outline: 1px solid #31353d;
+  outline-style: solid;
+  outline-width: 1px;
   background-color: #3f4552; /* primaryLight from colours.ts */
 }
 

--- a/src/components/css/PhoneNumber.css
+++ b/src/components/css/PhoneNumber.css
@@ -11,7 +11,7 @@
 .PhoneInputInput:focus {
   outline-style: solid !important;
   outline-width: 2px !important;
-  outline-color: #90caf9; /* This is muiActive and never gets applied */
+  outline-color: #90caf9; /* This is muiFocus and never gets applied */
 }
 
 .phone-wrapper {

--- a/src/components/css/TaskModal.css
+++ b/src/components/css/TaskModal.css
@@ -90,7 +90,7 @@ label span {
 }
 
 .react-datepicker__input-container input:hover {
-  border: 1px solid rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.8); /* muiHover from colours.ts */
 }
 
 .react-datepicker__input-container input:focus {

--- a/src/components/css/TaskModal.css
+++ b/src/components/css/TaskModal.css
@@ -95,5 +95,5 @@ label span {
 
 .react-datepicker__input-container input:focus {
   height: 38px; /* reduce height to account for increase in border thickness */
-  border: 2px solid #90caf9; /* muiActive from colours.ts */
+  border: 2px solid #90caf9; /* muiFocus from colours.ts */
 }

--- a/src/components/css/TaskModal.css
+++ b/src/components/css/TaskModal.css
@@ -95,5 +95,5 @@ label span {
 
 .react-datepicker__input-container input:focus {
   height: 38px; /* reduce height to account for increase in border thickness */
-  border: 2px solid #1976d2; /* muiActive from colours.ts */
+  border: 2px solid #90caf9; /* muiActive from colours.ts */
 }

--- a/src/components/css/TaskModal.css
+++ b/src/components/css/TaskModal.css
@@ -81,6 +81,7 @@ label span {
 .react-datepicker__input-container input {
   width: 93%;
   height: 40px;
+  color: #ffffff; /* textMain from colours.ts */
   border: 1px solid rgba(255, 255, 255, 0.3); /* muiBlur from colours.ts */
   border-radius: 4px;
   background-color: #3f524c; /* secondaryMain from colours.ts */

--- a/src/components/css/TaskModal.css
+++ b/src/components/css/TaskModal.css
@@ -81,7 +81,7 @@ label span {
 .react-datepicker__input-container input {
   width: 93%;
   height: 40px;
-  border: 1px solid rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.3); /* muiBlur from colours.ts */
   border-radius: 4px;
   background-color: #3f524c; /* secondaryMain from colours.ts */
   padding-left: 10px;

--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -133,7 +133,7 @@ function Homepage(): JSX.Element {
           <HeaderText text={headerRole} />
           {role !== "owner" && <HeaderText text={headerBusiness} />}
           {role === "owner" && <HeaderText text={headerBusinessId} />}
-          <PrimaryButton label="logout" type="button" onClick={signOut} />
+          <PrimaryButton label="Logout" type="button" onClick={signOut} />
         </header>
         <section style={styles.menuWrapper}>
           <div style={styles.menuItems}>

--- a/src/pages/LoginSignup.tsx
+++ b/src/pages/LoginSignup.tsx
@@ -32,12 +32,12 @@ function LoginSignup(): JSX.Element {
         <Login />
         <p style={styles.title}>Sign Up</p>
         <PrimaryButton
-          label="create user account"
+          label="Create User Account"
           type="button"
           onClick={userForm}
         />
         <PrimaryButton
-          label="create business account"
+          label="Create Business Account"
           type="button"
           onClick={businessForm}
         />

--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -5,10 +5,24 @@ import { ProvideAuth } from "./../util/useAuth";
 import RestrictedRoute from "./../routes/RestrictedRoute";
 import Homepage from "./../pages/Homepage";
 import LoginSignup from "./../pages/LoginSignup";
+import { secondaryMain, secondaryLight, textMain } from "../util/colours";
 
 const theme = createTheme({
   palette: {
     mode: "dark",
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          backgroundColor: secondaryMain,
+          "&:hover": {
+            backgroundColor: secondaryLight,
+          },
+          color: textMain,
+        },
+      },
+    },
   },
 });
 

--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -20,6 +20,7 @@ const theme = createTheme({
             backgroundColor: secondaryLight,
           },
           color: textMain,
+          textTransform: "none",
         },
       },
     },

--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -1,10 +1,16 @@
 import { useEffect } from "react";
 import { Route, Switch } from "react-router-dom";
-
+import { createTheme, ThemeProvider } from "@mui/material";
 import { ProvideAuth } from "./../util/useAuth";
 import RestrictedRoute from "./../routes/RestrictedRoute";
 import Homepage from "./../pages/Homepage";
 import LoginSignup from "./../pages/LoginSignup";
+
+const theme = createTheme({
+  palette: {
+    mode: "dark",
+  },
+});
 
 function App(): JSX.Element {
   useEffect(() => {
@@ -14,14 +20,16 @@ function App(): JSX.Element {
   return (
     <div>
       <ProvideAuth>
-        <Switch>
-          <RestrictedRoute path="/home">
-            <Homepage />
-          </RestrictedRoute>
-          <Route path="/">
-            <LoginSignup />
-          </Route>
-        </Switch>
+        <ThemeProvider theme={theme}>
+          <Switch>
+            <RestrictedRoute path="/home">
+              <Homepage />
+            </RestrictedRoute>
+            <Route path="/">
+              <LoginSignup />
+            </Route>
+          </Switch>
+        </ThemeProvider>
       </ProvideAuth>
     </div>
   );

--- a/src/util/colours.ts
+++ b/src/util/colours.ts
@@ -14,6 +14,6 @@ export const tertiaryLight = "#00A693";
 export const textMain = "#FFFFFF";
 export const textAlt = "#000000";
 export const muiError = "#d32f2f"; // Same as MUI error colour.
-export const muiActive = "#90caf9"; // Same as MUI active field colour.
+export const muiFocus = "#90caf9"; // Same as MUI field colour when focused.
 
 export const buttonShadow = "0px 3px 5px rgba(0, 0, 0, 0.2)";

--- a/src/util/colours.ts
+++ b/src/util/colours.ts
@@ -14,6 +14,7 @@ export const tertiaryLight = "#00A693";
 export const textMain = "#FFFFFF";
 export const textAlt = "#000000";
 export const muiError = "#d32f2f"; // Same as MUI error colour.
+export const muiBlur = "rgba(255, 255, 255, 0.3)"; // Same as MUI field colour when not focused.
 export const muiFocus = "#90caf9"; // Same as MUI field colour when focused.
 
 export const buttonShadow = "0px 3px 5px rgba(0, 0, 0, 0.2)";

--- a/src/util/colours.ts
+++ b/src/util/colours.ts
@@ -15,6 +15,7 @@ export const textMain = "#FFFFFF";
 export const textAlt = "#000000";
 export const muiError = "#d32f2f"; // Same as MUI error colour.
 export const muiBlur = "rgba(255, 255, 255, 0.3)"; // Same as MUI field colour when not focused.
+export const muiHover = "rgba(255, 255, 255, 0.8)"; // Same as MUI field colour when hovering.
 export const muiFocus = "#90caf9"; // Same as MUI field colour when focused.
 
 export const buttonShadow = "0px 3px 5px rgba(0, 0, 0, 0.2)";

--- a/src/util/colours.ts
+++ b/src/util/colours.ts
@@ -14,6 +14,6 @@ export const tertiaryLight = "#00A693";
 export const textMain = "#FFFFFF";
 export const textAlt = "#000000";
 export const muiError = "#d32f2f"; // Same as MUI error colour.
-export const muiActive = "#1976d2"; // Same as MUI active field colour.
+export const muiActive = "#90caf9"; // Same as MUI active field colour.
 
 export const buttonShadow = "0px 3px 5px rgba(0, 0, 0, 0.2)";


### PR DESCRIPTION
+ Create a new theme that is propagated throughout the app to all Material UI components. Set to dark mode. Overrride buttons to keep original colour scheme.
+ Update `colours.ts` to reflect MUI dark mode. Add some more colours to cover hover and blurred states (`muiHover` and `muiBlur`). 
+ Update non-MUI components with the new colours so that they match MUI dark mode.
+ Fix `PhoneNumber` bug so that it gives the correct colours when hovering, focused and blurred etc. There was actually quite a bit to this.