### PR TITLE
Hide password

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fullcalendar/daygrid": "^5.9.0",
         "@fullcalendar/list": "^5.9.0",
         "@fullcalendar/react": "^5.9.0",
+        "@mui/icons-material": "^5.10.16",
         "@mui/material": "^5.10.13",
         "@mui/styled-engine-sc": "^5.10.6",
         "firebase": "^8.4.3",
@@ -2617,6 +2618,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.10.16",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.10.16.tgz",
+      "integrity": "sha512-jjCc0IF6iyLiucQCu5igg3fOscSqbbvRCmyRxXgzOcLR56B0sg2L8o+ZfJ0dAg59+wvgtXaxvjze/mJg0B4iWA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {
@@ -23929,6 +23955,14 @@
       "version": "5.10.13",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.13.tgz",
       "integrity": "sha512-zWkWPV/SaNdsIdxAWiuVGZ+Ue3BkfSIlU/BFIrJmuUcwiIa7gQsbI/DOpj1KzLvqZhdEe2wC1aG4nCHfzgc1Hg=="
+    },
+    "@mui/icons-material": {
+      "version": "5.10.16",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.10.16.tgz",
+      "integrity": "sha512-jjCc0IF6iyLiucQCu5igg3fOscSqbbvRCmyRxXgzOcLR56B0sg2L8o+ZfJ0dAg59+wvgtXaxvjze/mJg0B4iWA==",
+      "requires": {
+        "@babel/runtime": "^7.20.1"
+      }
     },
     "@mui/material": {
       "version": "5.10.13",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@fullcalendar/daygrid": "^5.9.0",
     "@fullcalendar/list": "^5.9.0",
     "@fullcalendar/react": "^5.9.0",
+    "@mui/icons-material": "^5.10.16",
     "@mui/material": "^5.10.13",
     "@mui/styled-engine-sc": "^5.10.6",
     "firebase": "^8.4.3",

--- a/src/components/CreateBusiness.tsx
+++ b/src/components/CreateBusiness.tsx
@@ -4,6 +4,7 @@ import validator from "validator";
 import { TextField } from "@mui/material";
 import PhoneNumber from "./PhoneNumber";
 import PrimaryButton from "./PrimaryButton";
+import PasswordField from "./PasswordField";
 import { postFormDataAsJson } from "../util/helpers";
 import { useAuth } from "../util/useAuth";
 import { StyleSheet } from "../util/types";
@@ -51,10 +52,6 @@ function CreateBusiness(): JSX.Element {
 
   function handleEmail(event: ChangeEvent<HTMLInputElement>): void {
     setEmail(event.currentTarget.value);
-  }
-
-  function handlePassword(event: ChangeEvent<HTMLInputElement>): void {
-    setPassword(event.currentTarget.value);
   }
 
   async function createBusiness(
@@ -115,15 +112,6 @@ function CreateBusiness(): JSX.Element {
       setEmailHelperText("");
     }
   }, [email]);
-
-  // Display password validation in DOM as user types.
-  useEffect(() => {
-    if (password && password.length < 8) {
-      setPasswordHelperText("Needs to be > 7 characters");
-    } else {
-      setPasswordHelperText("");
-    }
-  }, [password]);
 
   // Decide if the Submit button should be disabled.
   useEffect(() => {
@@ -197,14 +185,11 @@ function CreateBusiness(): JSX.Element {
           helperText={emailHelperText}
           sx={styles.inputField}
         />
-        <TextField
-          label="Password"
-          value={password}
-          type="password"
-          onChange={handlePassword}
-          error={!!passwordHelperText}
-          helperText={passwordHelperText}
-          sx={styles.inputField}
+        <PasswordField
+          password={password}
+          setPassword={setPassword}
+          passwordHelperText={passwordHelperText}
+          setPasswordHelperText={setPasswordHelperText}
         />
         <PrimaryButton label="Submit" type="submit" disabled={loginDisabled} />
       </form>

--- a/src/components/CreateBusiness.tsx
+++ b/src/components/CreateBusiness.tsx
@@ -200,6 +200,7 @@ function CreateBusiness(): JSX.Element {
         <TextField
           label="Password"
           value={password}
+          type="password"
           onChange={handlePassword}
           error={!!passwordHelperText}
           helperText={passwordHelperText}

--- a/src/components/CreateUser.tsx
+++ b/src/components/CreateUser.tsx
@@ -4,6 +4,7 @@ import validator from "validator";
 import { TextField } from "@mui/material";
 import PhoneNumber from "./PhoneNumber";
 import PrimaryButton from "./PrimaryButton";
+import PasswordField from "./PasswordField";
 import { postFormDataAsJson } from "../util/helpers";
 import { useAuth } from "../util/useAuth";
 import { StyleSheet } from "../util/types";
@@ -36,10 +37,6 @@ function CreateUser(): JSX.Element {
 
   function handleEmail(event: ChangeEvent<HTMLInputElement>): void {
     setEmail(event.currentTarget.value);
-  }
-
-  function handlePassword(event: ChangeEvent<HTMLInputElement>): void {
-    setPassword(event.currentTarget.value);
   }
 
   function handleBusinessId(event: ChangeEvent<HTMLInputElement>): void {
@@ -88,15 +85,6 @@ function CreateUser(): JSX.Element {
       setEmailHelperText("");
     }
   }, [email]);
-
-  // Display password validation in DOM as user types.
-  useEffect(() => {
-    if (password && password.length < 8) {
-      setPasswordHelperText("Needs to be > 7 characters");
-    } else {
-      setPasswordHelperText("");
-    }
-  }, [password]);
 
   // Display business ID validation in DOM as user types.
   useEffect(() => {
@@ -159,14 +147,11 @@ function CreateUser(): JSX.Element {
           helperText={emailHelperText}
           sx={styles.inputField}
         />
-        <TextField
-          label="Password"
-          value={password}
-          type="password"
-          onChange={handlePassword}
-          error={!!passwordHelperText}
-          helperText={passwordHelperText}
-          sx={styles.inputField}
+        <PasswordField
+          password={password}
+          setPassword={setPassword}
+          passwordHelperText={passwordHelperText}
+          setPasswordHelperText={setPasswordHelperText}
         />
         <TextField
           label="Business ID"

--- a/src/components/CreateUser.tsx
+++ b/src/components/CreateUser.tsx
@@ -162,6 +162,7 @@ function CreateUser(): JSX.Element {
         <TextField
           label="Password"
           value={password}
+          type="password"
           onChange={handlePassword}
           error={!!passwordHelperText}
           helperText={passwordHelperText}

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -3,6 +3,7 @@ import { Redirect } from "react-router-dom";
 import validator from "validator";
 import TextField from "@mui/material/TextField";
 import PrimaryButton from "./PrimaryButton";
+import PasswordField from "./PasswordField";
 import { useAuth } from "../util/useAuth";
 import { StyleSheet } from "../util/types";
 import { secondaryMain } from "../util/colours";
@@ -18,10 +19,6 @@ function Login(): JSX.Element {
 
   function handleEmail(event: ChangeEvent<HTMLInputElement>): void {
     setEmail(event.currentTarget.value);
-  }
-
-  function handlePassword(event: ChangeEvent<HTMLInputElement>): void {
-    setPassword(event.currentTarget.value);
   }
 
   async function login(
@@ -53,15 +50,6 @@ function Login(): JSX.Element {
     }
   }, [email]);
 
-  // Display password validation in DOM as user types.
-  useEffect(() => {
-    if (password && password.length < 8) {
-      setPasswordHelperText("Needs to be > 7 characters");
-    } else {
-      setPasswordHelperText("");
-    }
-  }, [password]);
-
   // Decide if the Login button should be disabled
   useEffect(() => {
     if (!email || !password || emailHelperText || passwordHelperText) {
@@ -82,14 +70,11 @@ function Login(): JSX.Element {
           helperText={emailHelperText}
           sx={styles.inputField}
         />
-        <TextField
-          label="Password"
-          value={password}
-          type="password"
-          onChange={handlePassword}
-          error={passwordHelperText ? true : false}
-          helperText={passwordHelperText}
-          sx={styles.inputField}
+        <PasswordField
+          password={password}
+          setPassword={setPassword}
+          passwordHelperText={passwordHelperText}
+          setPasswordHelperText={setPasswordHelperText}
         />
         <PrimaryButton label="Login" type="submit" disabled={loginDisabled} />
       </form>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -85,6 +85,7 @@ function Login(): JSX.Element {
         <TextField
           label="Password"
           value={password}
+          type="password"
           onChange={handlePassword}
           error={passwordHelperText ? true : false}
           helperText={passwordHelperText}

--- a/src/components/PasswordField.tsx
+++ b/src/components/PasswordField.tsx
@@ -1,0 +1,68 @@
+import { useState, useEffect, ChangeEvent } from "react";
+import { FormControl, OutlinedInput, InputLabel } from "@mui/material";
+import { FormHelperText, InputAdornment, IconButton } from "@mui/material";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
+import { StyleSheet } from "../util/types";
+
+function PasswordField(props) {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const { password, setPassword } = props;
+  const { passwordHelperText, setPasswordHelperText } = props;
+
+  function handlePassword(event: ChangeEvent<HTMLInputElement>): void {
+    setPassword(event.currentTarget.value);
+  }
+
+  function toggleShowPassword() {
+    setShowPassword(!showPassword);
+  }
+
+  // Display password validation in DOM as user types.
+  useEffect(() => {
+    if (password && password.length < 8) {
+      setPasswordHelperText("Needs to be > 7 characters");
+    } else {
+      setPasswordHelperText("");
+    }
+  }, [password]);
+
+  return (
+    <FormControl sx={styles.inputField}>
+      <InputLabel htmlFor="password-field" error={!!passwordHelperText}>
+        Password
+      </InputLabel>
+      <OutlinedInput
+        id="password-field"
+        label="Password"
+        value={password}
+        type={showPassword ? "text" : "password"}
+        onChange={handlePassword}
+        error={!!passwordHelperText}
+        endAdornment={
+          <InputAdornment position="end">
+            <IconButton
+              aria-label="toggle password visibility"
+              onClick={toggleShowPassword}
+              edge="end"
+            >
+              {showPassword ? <VisibilityOff /> : <Visibility />}
+            </IconButton>
+          </InputAdornment>
+        }
+      />
+      <FormHelperText error={!!passwordHelperText}>
+        {passwordHelperText}
+      </FormHelperText>
+    </FormControl>
+  );
+}
+
+export default PasswordField;
+
+const styles: StyleSheet = {
+  inputField: {
+    width: "80%",
+    marginBottom: "15px",
+  },
+};


### PR DESCRIPTION
Create and implement a new `<PasswordField/>` component that is basically a `<TextField/>` with an `endAdornment` prop that is used to toggle visibility. This was achieved by breaking a `<TextField/>` into it's constituent parts which allowed the use of this prop in the `<OutlinedInput/>` sub-component. The prop is not available on a plain `<TextField/>` which is the reason that all of this was necessary.