### PR TITLE
Improve logout alert

### DIFF
--- a/src/pages/LoginSignup.tsx
+++ b/src/pages/LoginSignup.tsx
@@ -14,6 +14,9 @@ function LoginSignup(props): JSX.Element {
 
   const { showAlert } = props;
 
+  const vertical = "top";
+  const horizontal = "center";
+
   function userForm() {
     setUserFormActive(true);
     setBusinessFormActive(false);
@@ -40,7 +43,11 @@ function LoginSignup(props): JSX.Element {
           type="button"
           onClick={businessForm}
         />
-        <Snackbar open={showAlert} autoHideDuration={3000}>
+        <Snackbar
+          open={showAlert}
+          autoHideDuration={3000}
+          anchorOrigin={{ vertical, horizontal }}
+        >
           <Alert severity="info" variant="outlined">
             You have been logged out
           </Alert>

--- a/src/pages/LoginSignup.tsx
+++ b/src/pages/LoginSignup.tsx
@@ -12,7 +12,7 @@ function LoginSignup(props): JSX.Element {
   const [userFormActive, setUserFormActive] = useState(false);
   const [businessFormActive, setBusinessFormActive] = useState(false);
 
-  const { showAlert } = props;
+  const { showAlert, setShowAlert } = props;
 
   const vertical = "top";
   const horizontal = "center";
@@ -45,6 +45,7 @@ function LoginSignup(props): JSX.Element {
         />
         <Snackbar
           open={showAlert}
+          onClose={() => setShowAlert(false)}
           autoHideDuration={3000}
           anchorOrigin={{ vertical, horizontal }}
         >

--- a/src/pages/LoginSignup.tsx
+++ b/src/pages/LoginSignup.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Snackbar, Alert } from "@mui/material";
 import Login from "../components/Login";
 import PrimaryButton from "../components/PrimaryButton";
 import CreateUser from "../components/CreateUser";
@@ -7,9 +8,11 @@ import { primaryMain, primaryLight, secondaryMain } from "../util/colours";
 import { textMain } from "../util/colours";
 import { StyleSheet } from "../util/types";
 
-function LoginSignup(): JSX.Element {
+function LoginSignup(props): JSX.Element {
   const [userFormActive, setUserFormActive] = useState(false);
   const [businessFormActive, setBusinessFormActive] = useState(false);
+
+  const { showAlert } = props;
 
   function userForm() {
     setUserFormActive(true);
@@ -37,6 +40,11 @@ function LoginSignup(): JSX.Element {
           type="button"
           onClick={businessForm}
         />
+        <Snackbar open={showAlert} autoHideDuration={3000}>
+          <Alert severity="info" variant="outlined">
+            You have been logged out
+          </Alert>
+        </Snackbar>
       </header>
       {userFormActive && <CreateUser />}
       {businessFormActive && <CreateBusiness />}

--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Route, Switch } from "react-router-dom";
 import { createTheme, ThemeProvider } from "@mui/material";
 import RestrictedRoute from "../routes/RestrictedRoute";
@@ -8,6 +8,8 @@ import { ProvideAuth } from "../util/useAuth";
 import { secondaryMain, secondaryLight, textMain } from "../util/colours";
 
 function App(): JSX.Element {
+  const [showAlert, setShowAlert] = useState(false);
+
   useEffect(() => {
     document.title = "Onit";
   }, []);
@@ -17,11 +19,11 @@ function App(): JSX.Element {
       <ProvideAuth>
         <ThemeProvider theme={theme}>
           <Switch>
-            <RestrictedRoute path="/home">
+            <RestrictedRoute path="/home" setShowAlert={setShowAlert}>
               <Homepage />
             </RestrictedRoute>
             <Route path="/">
-              <LoginSignup />
+              <LoginSignup showAlert={showAlert} />
             </Route>
           </Switch>
         </ThemeProvider>

--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -23,7 +23,7 @@ function App(): JSX.Element {
               <Homepage />
             </RestrictedRoute>
             <Route path="/">
-              <LoginSignup showAlert={showAlert} />
+              <LoginSignup showAlert={showAlert} setShowAlert={setShowAlert} />
             </Route>
           </Switch>
         </ThemeProvider>

--- a/src/routes/RestrictedRoute.tsx
+++ b/src/routes/RestrictedRoute.tsx
@@ -4,6 +4,9 @@ import { useAuth } from "../util/useAuth";
 // A wrapper for <Route> that redirects to the login screen if you're not yet authenticated.
 function RestrictedRoute({ children, ...rest }) {
   const auth = useAuth();
+
+  const { setShowAlert } = rest;
+
   return (
     <Route
       {...rest}
@@ -18,7 +21,7 @@ function RestrictedRoute({ children, ...rest }) {
                 state: { from: location },
               }}
             />
-            {alert("You have been logged out.")}
+            {setShowAlert(true)}
           </div>
         )
       }


### PR DESCRIPTION
Replace the generic logout `alert` from `window` with a custom Material UI one. This comprises of an `<Alert/>` wrapped in a `<Snackbar/>` component. Looks much better than the generic one and is customisable. Appears for 3 seconds after logout before closing. This is in contrast to the generic `alert` that presents a dialog that the user must acknowledge and close manually.