### PR TITLE
Fix eslint issues

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -28,5 +28,10 @@
     "firebase-functions-test": "^0.2.0",
     "typescript": "^4.9.3"
   },
+  "eslintConfig": {
+    "rules": {
+      "@typescript-eslint/no-explicit-any": "off"
+    }
+  },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -72,34 +72,6 @@
       "/functions/lib/**/*"
     ],
     "rules": {
-      "semi": [
-        "warn",
-        "always"
-      ],
-      "indent": [
-        "warn",
-        "tab"
-      ],
-      "quotes": [
-        "warn",
-        "double"
-      ],
-      "object-curly-spacing": [
-        "warn",
-        "always"
-      ],
-      "space-before-function-paren": [
-        "warn",
-        "always"
-      ],
-      "no-multiple-empty-lines": [
-        "warn",
-        {
-          "max": 2,
-          "maxBOF": 0,
-          "maxEOF": 0
-        }
-      ],
       "@typescript-eslint/explicit-module-boundary-types": [
         "off",
         {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,12 @@
         {
           "allowArgumentsExplicitlyTypedAsAny": true
         }
+      ],
+      "import/no-duplicates": [
+        "off",
+        {
+          "considerQueryString": true
+        }
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
       "/functions/lib/**/*"
     ],
     "rules": {
+      "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/explicit-module-boundary-types": [
         "off",
         {

--- a/src/components/CreateBusiness.tsx
+++ b/src/components/CreateBusiness.tsx
@@ -93,7 +93,7 @@ function CreateBusiness(): JSX.Element {
     } else {
       setPostcodeHelperText("");
     }
-  }, [postcode]);
+  }, [postcode, locale]);
 
   // Display phone number validation in DOM as user types.
   useEffect(() => {
@@ -133,7 +133,20 @@ function CreateBusiness(): JSX.Element {
     } else {
       setLoginDisabled(false);
     }
-  });
+  }, [
+    businessName,
+    address1,
+    address2,
+    city,
+    postcode,
+    phone,
+    email,
+    password,
+    postcodeHelperText,
+    phoneHelperText,
+    emailHelperText,
+    passwordHelperText,
+  ]);
 
   return (
     <div>

--- a/src/components/CreateUser.tsx
+++ b/src/components/CreateUser.tsx
@@ -115,7 +115,17 @@ function CreateUser(): JSX.Element {
     } else {
       setLoginDisabled(false);
     }
-  });
+  }, [
+    firstName,
+    lastName,
+    email,
+    password,
+    businessId,
+    phoneHelperText,
+    emailHelperText,
+    passwordHelperText,
+    businessIdHelperText,
+  ]);
 
   return (
     <div>

--- a/src/components/DateSelect.tsx
+++ b/src/components/DateSelect.tsx
@@ -46,7 +46,14 @@ function DateSelect(props): JSX.Element {
     } else {
       setDurationValid(false); // Default to invalid.
     }
-  }, [allDay, durationHours, durationMinutes, hoursHelperText, minsHelperText]);
+  }, [
+    allDay,
+    durationHours,
+    durationMinutes,
+    hoursHelperText,
+    minsHelperText,
+    setDurationValid,
+  ]);
 
   if (allDay) {
     return (

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -57,7 +57,7 @@ function Login(): JSX.Element {
     } else {
       setLoginDisabled(false);
     }
-  });
+  }, [email, password, emailHelperText, passwordHelperText]);
 
   return (
     <div style={styles.wrapper}>

--- a/src/components/PasswordField.tsx
+++ b/src/components/PasswordField.tsx
@@ -25,7 +25,7 @@ function PasswordField(props) {
     } else {
       setPasswordHelperText("");
     }
-  }, [password]);
+  }, [password, setPasswordHelperText]);
 
   return (
     <FormControl sx={styles.inputField}>

--- a/src/components/PhoneNumber.tsx
+++ b/src/components/PhoneNumber.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import PhoneInput, { PhoneInputProps } from "react-phone-number-input";
 import { muiBlur, muiError, muiFocus, muiHover } from "../util/colours";
 import { COUNTRY_CODE } from "../util/constants";
@@ -45,7 +45,7 @@ function PhoneNumber(props: PhoneNumberProps): JSX.Element {
     setInFocus(false);
   }
 
-  function setOutline() {
+  const setOutline = useCallback(() => {
     if (helperText) {
       setErrorOutline();
     } else if (inFocus) {
@@ -53,7 +53,9 @@ function PhoneNumber(props: PhoneNumberProps): JSX.Element {
     } else {
       setBlurredOutline();
     }
-  }
+    // We don't need setters in the dependency array, so disable eslint check.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [helperText, inFocus]);
 
   useEffect(() => {
     if (!isLoaded) {

--- a/src/components/PhoneNumber.tsx
+++ b/src/components/PhoneNumber.tsx
@@ -62,7 +62,7 @@ function PhoneNumber(props: PhoneNumberProps): JSX.Element {
       setOutline();
     }
     setIsLoaded(true);
-  });
+  }, [isLoaded, setOutline]);
 
   return (
     <div className="phone-wrapper">

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -164,7 +164,7 @@ function TaskModal(props): JSX.Element {
   const fetchTasks = useCallback(async () => {
     const newTasks = await getTasks(role, businessId, userId);
     setTasks(newTasks);
-  }, [role, businessId, userId]);
+  }, [role, businessId, userId, setTasks]);
 
   useEffect(() => {
     if (businessId) getUsers();
@@ -182,7 +182,7 @@ function TaskModal(props): JSX.Element {
     } else {
       setCreateTaskDisabled(false);
     }
-  });
+  }, [title, message, startDate, durationValid, assignees.length]);
 
   return (
     <Modal

--- a/src/components/UserTable.tsx
+++ b/src/components/UserTable.tsx
@@ -84,7 +84,7 @@ function UserTable(props) {
       columnArray.push(header);
     }
     return columnArray;
-  }, [role, changeRole]);
+  }, [role, changeRole, refresh]);
 
   const tableInstance = useTable({ columns, data });
 


### PR DESCRIPTION
There were many ESLint issues from the last few feature branches that surfaced with the linting that occured pre-deployment. Most had to do with Prettier rules conflicting with ESLint ones. The latter rules were removed as Prettier should be responsible for all style-related decisions.

Also added memoisation via the `useCallback` hooks and added missing values to the `useEffect` dependency arrays at various locations.